### PR TITLE
Nit: Improve view transition detection

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,7 +75,7 @@
 }
 
 
-@supports (view-transition-name: test) {
+@supports selector(:active-view-transition-type(test)) {
   [data-support] [data-support-yes] {
       display: flex;
   }
@@ -84,7 +84,7 @@
   }
 }
 
-@supports not (view-transition-name: test) {
+@supports not selector(:active-view-transition-type(test)) {
   [data-support] [data-support-yes] {
       display: none;
   }


### PR DESCRIPTION
The VT detection includes Firefox, which currently does not support passing an object (with `update` and `types` properties) to `document.startViewTransition` as the first argument. Since React requires this, users will not see any animations, even though there’s a badge stating: `Your browser supports View Transitions.`

This PR makes the detection more precise by testing support for the `:active-view-transition-type` pseudo-class.
